### PR TITLE
DynamicReadSerializerMixin Performance Update

### DIFF
--- a/dynamic_read/serializers.py
+++ b/dynamic_read/serializers.py
@@ -19,7 +19,7 @@ class ChildNotSupported(Exception):
 
 @lru_cache(maxsize=1024)
 def split_fields(fields: tuple):
-    return tuple((each.split("__") for each in fields))
+    return list((each.split("__") for each in fields))
 
 
 class DynamicReadSerializerMixin(object):


### PR DESCRIPTION
Updated DynamicReadSerializerMixin to use __slots__ for faster accessing of filter & omit fields
Rewrote fields calculation using set operations and creating a new dict instead of updating the existing one
Rewrote fields processing using group by to avoid iterating over all fields of the serializer